### PR TITLE
Fix compilation errors on GCC 14

### DIFF
--- a/convert.cpp
+++ b/convert.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <map>
 #include <string>
 #include <stdexcept>

--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,7 @@
 #include <elf.h>
 #include <fstream>
 #include <array>
+#include <algorithm>
 #include <vector>
 #include <cstring>
 #include <iomanip>


### PR DESCRIPTION
Fixes errors like:
````
elf-converter/main.cpp:117:48: error: no matching function for call to ‘search(std::__cxx11::basic_string<char>::iterator, std::__cxx11::basic_string<char>::iterator, const char*&, const char*)’
  117 |                         auto iter = std::search(args.begin(), args.end(), key, key + strlen(key));
      |                                     ~~~~~~~~~~~^~~~~~~~~~~~~~
````
and

````
elf-converter/convert.cpp:402:31: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
  402 |             auto reloc = std::find_if(relocs.begin(), relocs.end(), [currInstr, nextInstr](Elf64_Rela &reloc) {
      |
````